### PR TITLE
Improve reliability with session retries

### DIFF
--- a/stock_bot_real_data.py
+++ b/stock_bot_real_data.py
@@ -9,6 +9,7 @@ import time
 import schedule
 import tweepy
 import requests
+from utils import create_session
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import logging
@@ -42,6 +43,9 @@ class RealStockMarketBot:
         
         # News API key
         self.news_api_key = os.getenv('NEWS_API_KEY')
+
+        # HTTP session with retry logic for reliability
+        self.session = create_session()
         
         if not all([self.api_key, self.api_secret, self.access_token, self.access_token_secret]):
             raise ValueError("Missing X API credentials in .env file")
@@ -78,7 +82,7 @@ class RealStockMarketBot:
                 'outputsize': 'compact'
             }
             
-            response = requests.get(url, params=params, timeout=10)
+            response = self.session.get(url, params=params, timeout=10)
             data = response.json()
             
             if 'Time Series (Daily)' in data:
@@ -136,7 +140,7 @@ class RealStockMarketBot:
                 'apiKey': self.news_api_key
             }
             
-            response = requests.get(url, params=params, timeout=10)
+            response = self.session.get(url, params=params, timeout=10)
             data = response.json()
             
             if data.get('status') == 'ok' and data.get('articles'):

--- a/stock_bot_server.py
+++ b/stock_bot_server.py
@@ -9,6 +9,7 @@ import os
 import time
 import tweepy
 import requests
+from utils import create_session
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import logging
@@ -38,6 +39,9 @@ class ServerStockMarketBot:
         
         # News API key
         self.news_api_key = os.getenv('NEWS_API_KEY')
+
+        # HTTP session with retry logic
+        self.session = create_session()
         
         if not all([self.api_key, self.api_secret, self.access_token, self.access_token_secret]):
             raise ValueError("Missing X API credentials in environment variables")
@@ -74,7 +78,7 @@ class ServerStockMarketBot:
                 'outputsize': 'compact'
             }
             
-            response = requests.get(url, params=params, timeout=10)
+            response = self.session.get(url, params=params, timeout=10)
             data = response.json()
             
             if 'Time Series (Daily)' in data:
@@ -132,7 +136,7 @@ class ServerStockMarketBot:
                 'apiKey': self.news_api_key
             }
             
-            response = requests.get(url, params=params, timeout=10)
+            response = self.session.get(url, params=params, timeout=10)
             data = response.json()
             
             if data.get('status') == 'ok' and data.get('articles'):

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,22 @@
+import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+
+def create_session(retries: int = 3, backoff_factor: float = 0.5, status_forcelist=None) -> requests.Session:
+    """Create a requests Session with retry logic."""
+    if status_forcelist is None:
+        status_forcelist = [429, 500, 502, 503, 504]
+    session = requests.Session()
+    retry = Retry(
+        total=retries,
+        read=retries,
+        connect=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods=["HEAD", "GET", "OPTIONS"]
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session


### PR DESCRIPTION
## Summary
- add a small `utils` module providing a `create_session` helper
- use retry-enabled HTTP sessions in `stock_bot_real_data.py` and `stock_bot_server.py`

## Testing
- `python3 -m py_compile stock_bot_real_data.py stock_bot_server.py stock_bot_weekend_compact.py utils.py`
- `pip install schedule requests tweepy python-dotenv yfinance pandas numpy` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6879921bb40483239ec0962e1008710b