### PR TITLE
Add posting retries and usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Python bot that automatically posts stock market updates to X (Twitter) at 8:0
 - 📱 Posts formatted updates to X (Twitter)
 - 📰 Posts revenue report summaries on earnings days
 - 📝 Comprehensive logging
+- 🔁 Automatic retry logic for posting to X
 
 ## Prerequisites
 
@@ -19,6 +20,13 @@ A Python bot that automatically posts stock market updates to X (Twitter) at 8:0
 - X API credentials
 
 ## Setup Instructions
+
+### 0. Download the Repository
+
+```bash
+git clone https://github.com/<your-username>/stock-market-bot.git
+cd stock-market-bot
+```
 
 ### 1. Install Dependencies
 
@@ -70,6 +78,7 @@ The bot will:
 - Start the scheduler
 - Run market updates at 8:00 AM and 8:00 PM
 - Log all activities to `stock_bot.log`
+- The terminal window running the bot must remain open or the process must stay running in the background
 
 ### Running as a Service (Optional)
 

--- a/revenue_report_bot.py
+++ b/revenue_report_bot.py
@@ -11,7 +11,7 @@ from datetime import datetime
 
 import tweepy
 from dotenv import load_dotenv
-from utils import create_session
+from utils import create_session, post_with_retry
 
 load_dotenv()
 
@@ -125,13 +125,7 @@ class RevenueReportBot:
         return message
 
     def post_to_x(self, message: str) -> bool:
-        try:
-            self.client.create_tweet(text=message)
-            logging.info("Successfully posted revenue report")
-            return True
-        except Exception as e:
-            logging.error(f"Error posting revenue report: {e}")
-            return False
+        return post_with_retry(self.client, message)
 
     def check_and_post_reports(self):
         """Check for new earnings reports and post revenue summaries."""

--- a/stock_bot_real_data.py
+++ b/stock_bot_real_data.py
@@ -9,7 +9,7 @@ import time
 import schedule
 import tweepy
 import requests
-from utils import create_session
+from utils import create_session, post_with_retry
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import logging
@@ -281,25 +281,17 @@ class RealStockMarketBot:
         return message
     
     def post_to_x(self, message):
-        """Post message to X"""
-        try:
-            # X has a 280 character limit
-            if len(message) > 280:
-                message = message[:277] + "..."
-            
-            # Debug: Print the message being posted
-            print(f"📝 Message to post ({len(message)} chars):")
-            print("-" * 40)
-            print(message)
-            print("-" * 40)
-            
-            response = self.client.create_tweet(text=message)
-            logging.info("Successfully posted to X")
-            return True
-            
-        except Exception as e:
-            logging.error(f"Error posting to X: {e}")
-            return False
+        """Post message to X with retries"""
+        if len(message) > 280:
+            message = message[:277] + "..."
+
+        # Debug: Print the message being posted
+        print(f"📝 Message to post ({len(message)} chars):")
+        print("-" * 40)
+        print(message)
+        print("-" * 40)
+
+        return post_with_retry(self.client, message)
     
     def run_market_update(self, is_morning=True):
         """Run the complete market update process"""

--- a/stock_bot_server.py
+++ b/stock_bot_server.py
@@ -9,7 +9,7 @@ import os
 import time
 import tweepy
 import requests
-from utils import create_session
+from utils import create_session, post_with_retry
 from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import logging
@@ -283,19 +283,10 @@ class ServerStockMarketBot:
         return message
     
     def post_to_x(self, message):
-        """Post message to X"""
-        try:
-            # X has a 280 character limit
-            if len(message) > 280:
-                message = message[:277] + "..."
-            
-            response = self.client.create_tweet(text=message)
-            logging.info("Successfully posted to X")
-            return True
-            
-        except Exception as e:
-            logging.error(f"Error posting to X: {e}")
-            return False
+        """Post message to X with retries"""
+        if len(message) > 280:
+            message = message[:277] + "..."
+        return post_with_retry(self.client, message)
     
     def run_market_update(self, is_morning=True):
         """Run the complete market update process"""

--- a/stock_bot_weekend_compact.py
+++ b/stock_bot_weekend_compact.py
@@ -14,6 +14,7 @@ from datetime import datetime, timedelta
 from dotenv import load_dotenv
 import logging
 import random
+from utils import post_with_retry
 
 # Load environment variables
 load_dotenv()
@@ -147,22 +148,13 @@ class CompactWeekendStockMarketBot:
         return message
     
     def post_to_x(self, message):
-        """Post message to X using v2 API"""
-        try:
-            # X has a 280 character limit
-            if len(message) > 280:
-                # Truncate but keep disclaimer
-                disclaimer = "\n\n⚠️ Not financial advice. Do your own research."
-                max_content = 280 - len(disclaimer)
-                message = message[:max_content] + disclaimer
-            
-            response = self.client.create_tweet(text=message)
-            logging.info("Successfully posted weekend prediction to X using v2 API")
-            return True
-            
-        except Exception as e:
-            logging.error(f"Error posting to X: {e}")
-            return False
+        """Post message to X using v2 API with retries"""
+        if len(message) > 280:
+            # Truncate but keep disclaimer
+            disclaimer = "\n\n⚠️ Not financial advice. Do your own research."
+            max_content = 280 - len(disclaimer)
+            message = message[:max_content] + disclaimer
+        return post_with_retry(self.client, message)
     
     def run_weekend_update(self, is_morning=True):
         """Run the weekend prediction update process"""

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,8 @@
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
+import logging
+import time
 
 
 def create_session(retries: int = 3, backoff_factor: float = 0.5, status_forcelist=None) -> requests.Session:
@@ -20,3 +22,20 @@ def create_session(retries: int = 3, backoff_factor: float = 0.5, status_forceli
     session.mount("http://", adapter)
     session.mount("https://", adapter)
     return session
+
+
+def post_with_retry(client, message: str, max_retries: int = 3, backoff_factor: float = 2.0) -> bool:
+    """Post a message to X with retry logic."""
+    for attempt in range(1, max_retries + 1):
+        try:
+            client.create_tweet(text=message)
+            logging.info("Successfully posted to X")
+            return True
+        except Exception as e:
+            logging.error(f"Attempt {attempt} to post failed: {e}")
+            if attempt < max_retries:
+                sleep_time = backoff_factor ** (attempt - 1)
+                logging.info(f"Retrying in {sleep_time} seconds...")
+                time.sleep(sleep_time)
+    logging.error("All attempts to post to X failed")
+    return False


### PR DESCRIPTION
## Summary
- add shared `post_with_retry` utility to ensure tweets retry on failures
- update bots to use the retry helper
- document repository download and runtime requirements

## Testing
- `python -m py_compile utils.py stock_bot_server.py stock_bot_weekend_compact.py stock_bot_real_data.py revenue_report_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_68c30104bc4c83238c74996b8b64c404