### PR TITLE
Add monitoring utilities and status tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+stock_bot.log
+monitoring/

--- a/README.md
+++ b/README.md
@@ -109,6 +109,22 @@ python revenue_report_bot.py
 
 This checks for newly released earnings and posts a short revenue summary to X.
 
+## Monitoring and Status Visibility
+
+- Every bot writes status snapshots to JSON files inside the `monitoring/`
+  directory (ignored by git). These files include the last successes,
+  failures, recent events, and metadata such as which tickers were posted.
+- Use the helper CLI to inspect the current state:
+
+  ```bash
+  python monitor_status.py
+  ```
+
+  Add `--events 10` to see more historical events or `--status-dir` to point to
+  a custom directory if you relocate the monitoring files.
+- Monitoring data is updated automatically whenever a scheduled run executes or
+  when the bot encounters notable errors such as API outages.
+
 ## What the Bot Posts
 
 The bot posts formatted updates like this:

--- a/monitor_status.py
+++ b/monitor_status.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""CLI helper to inspect monitoring data produced by the stock market bots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, Optional
+
+from monitoring import load_all_statuses
+
+
+def parse_timestamp(raw: Optional[str]) -> Optional[datetime]:
+    """Parse an ISO8601 timestamp stored in the monitoring files."""
+    if not raw:
+        return None
+    cleaned = raw.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def format_delta(delta) -> str:
+    seconds = int(delta.total_seconds())
+    if seconds < 0:
+        seconds = 0
+    if seconds < 60:
+        return f"{seconds}s"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h {minutes % 60}m"
+    days = hours // 24
+    return f"{days}d {hours % 24}h"
+
+
+def describe_timestamp(raw: Optional[str], now: datetime) -> str:
+    parsed = parse_timestamp(raw)
+    if not parsed:
+        return "never"
+    parsed = parsed.astimezone(timezone.utc)
+    return f"{parsed.strftime('%Y-%m-%d %H:%M:%S UTC')} ({format_delta(now - parsed)} ago)"
+
+
+def dump_metadata(metadata: Any) -> Iterable[str]:
+    if isinstance(metadata, dict) and metadata:
+        json_blob = json.dumps(metadata, indent=2, sort_keys=True)
+        for line in json_blob.splitlines():
+            yield line
+
+
+def render_status(state: Dict[str, Any], now: datetime, max_events: int) -> None:
+    bot_name = state.get('bot_name', 'unknown bot')
+    print(f"=== {bot_name} ===")
+    print(f"Last success: {describe_timestamp(state.get('last_success'), now)}")
+    print(f"Last failure: {describe_timestamp(state.get('last_failure'), now)}")
+    print(
+        f"Successes: {state.get('success_count', 0)} | Failures: {state.get('failure_count', 0)}"
+    )
+
+    runs = state.get('runs') or {}
+    if runs:
+        print("Last recorded runs:")
+        for run_name in sorted(runs):
+            run_info = runs[run_name]
+            timestamp = describe_timestamp(run_info.get('timestamp'), now)
+            status = run_info.get('status', 'unknown')
+            message = run_info.get('message')
+            print(f"  - {run_name}: {status} @ {timestamp}")
+            if message:
+                print(f"    {message}")
+            for line in dump_metadata(run_info.get('metadata')):
+                print(f"    {line}")
+    else:
+        print("No runs recorded yet.")
+
+    events = state.get('events') or []
+    if events:
+        print(f"Recent events (last {min(len(events), max_events)} shown):")
+        for event in events[-max_events:]:
+            event_ts = describe_timestamp(event.get('timestamp'), now)
+            event_type = event.get('type', 'info')
+            message = event.get('message', '')
+            print(f"  - [{event_type}] {event_ts}: {message}")
+            for line in dump_metadata(event.get('metadata')):
+                print(f"    {line}")
+    else:
+        print("No events recorded yet.")
+    print()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Display monitoring information for the stock market bots.",
+    )
+    parser.add_argument(
+        "--status-dir",
+        default="monitoring",
+        help="Directory containing <bot>_status.json files (default: monitoring)",
+    )
+    parser.add_argument(
+        "--events",
+        type=int,
+        default=5,
+        help="Number of recent events to show for each bot (default: 5)",
+    )
+    args = parser.parse_args()
+
+    statuses = load_all_statuses(args.status_dir)
+    if not statuses:
+        print(f"No monitoring data found in {args.status_dir}.")
+        return
+
+    now = datetime.now(timezone.utc)
+    for state in sorted(statuses, key=lambda item: item.get('bot_name', '')):
+        render_status(state, now, max_events=max(1, args.events))
+
+
+if __name__ == "__main__":
+    main()

--- a/monitoring.py
+++ b/monitoring.py
@@ -1,0 +1,187 @@
+"""Monitoring utilities for the stock market bots.
+
+This module provides a lightweight monitoring helper that persists
+structured status information to JSON files. The monitor tracks the most
+recent runs, aggregates success and failure counts, and stores a short
+history of notable events. Data is written atomically so the files can be
+safely tailed or inspected by other processes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class BotMonitor:
+    """Persist simple status information for a bot run."""
+
+    def __init__(
+        self,
+        bot_name: str,
+        status_dir: str = "monitoring",
+        max_events: int = 50,
+    ) -> None:
+        self.bot_name = bot_name
+        self.status_dir = Path(status_dir)
+        self.status_file = self.status_dir / f"{bot_name}_status.json"
+        self.max_events = max_events
+        self._lock = threading.Lock()
+
+        # Ensure the monitoring directory exists.
+        try:
+            self.status_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            logging.error("Could not create monitoring directory %s: %s", self.status_dir, exc)
+
+        self._state: Dict[str, Any] = self._load_state()
+
+    # ------------------------------------------------------------------
+    def _load_state(self) -> Dict[str, Any]:
+        """Load existing monitoring state from disk."""
+        if self.status_file.exists():
+            try:
+                with self.status_file.open("r", encoding="utf-8") as handle:
+                    data = json.load(handle)
+                if isinstance(data, dict):
+                    return self._apply_defaults(data)
+            except (json.JSONDecodeError, OSError) as exc:
+                logging.warning(
+                    "Could not read monitoring state from %s: %s", self.status_file, exc
+                )
+        return self._apply_defaults({})
+
+    def _apply_defaults(self, state: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensure required keys exist in the monitoring state."""
+        state.setdefault("bot_name", self.bot_name)
+        state.setdefault("last_updated", None)
+        state.setdefault("last_success", None)
+        state.setdefault("last_failure", None)
+        state.setdefault("success_count", 0)
+        state.setdefault("failure_count", 0)
+        state.setdefault("events", [])
+        state.setdefault("runs", {})
+        return state
+
+    def _save_state(self) -> None:
+        """Persist monitoring state atomically."""
+        tmp_path = self.status_file.with_suffix(".tmp")
+        try:
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                json.dump(self._state, handle, indent=2)
+            os.replace(tmp_path, self.status_file)
+        except OSError as exc:
+            logging.error("Failed to write monitoring state to %s: %s", self.status_file, exc)
+
+    def _record_event_locked(
+        self,
+        timestamp: str,
+        event_type: str,
+        message: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        event: Dict[str, Any] = {
+            "timestamp": timestamp,
+            "type": event_type,
+            "message": message,
+        }
+        if metadata:
+            event["metadata"] = metadata
+
+        events: List[Dict[str, Any]] = self._state.setdefault("events", [])
+        events.append(event)
+        if len(events) > self.max_events:
+            events = events[-self.max_events :]
+        self._state["events"] = events
+
+        self._state["last_updated"] = timestamp
+        if event_type == "success":
+            self._state["last_success"] = timestamp
+            self._state["success_count"] = self._state.get("success_count", 0) + 1
+        elif event_type == "error":
+            self._state["last_failure"] = timestamp
+            self._state["failure_count"] = self._state.get("failure_count", 0) + 1
+
+    def record_event(
+        self,
+        event_type: str,
+        message: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Record a generic monitoring event."""
+        timestamp = datetime.now(timezone.utc).isoformat()
+        with self._lock:
+            self._record_event_locked(timestamp, event_type, message, metadata)
+            self._save_state()
+
+    def record_run(
+        self,
+        run_type: str,
+        status: str,
+        message: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Record the outcome of a scheduled run."""
+        timestamp = datetime.now(timezone.utc).isoformat()
+        run_entry: Dict[str, Any] = {
+            "status": status,
+            "timestamp": timestamp,
+        }
+        if message:
+            run_entry["message"] = message
+        if metadata:
+            run_entry["metadata"] = metadata
+
+        with self._lock:
+            runs: Dict[str, Any] = self._state.setdefault("runs", {})
+            runs[run_type] = run_entry
+
+            if status == "success":
+                event_type = "success"
+            elif status == "error":
+                event_type = "error"
+            elif status == "warning":
+                event_type = "warning"
+            else:
+                event_type = "info"
+
+            default_message = f"{run_type} run reported {status}"
+            self._record_event_locked(
+                timestamp,
+                event_type,
+                message or default_message,
+                metadata,
+            )
+            self._save_state()
+
+    def get_state(self) -> Dict[str, Any]:
+        """Return a deep copy of the current monitoring state."""
+        with self._lock:
+            # Using JSON round-trip to create a deep copy without external deps.
+            return json.loads(json.dumps(self._state))
+
+
+def load_all_statuses(status_dir: str = "monitoring") -> List[Dict[str, Any]]:
+    """Load the monitoring state for every tracked bot."""
+    status_path = Path(status_dir)
+    if not status_path.exists() or not status_path.is_dir():
+        return []
+
+    statuses: List[Dict[str, Any]] = []
+    for file_path in sorted(status_path.glob("*_status.json")):
+        try:
+            with file_path.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+            if isinstance(data, dict):
+                statuses.append(data)
+        except (json.JSONDecodeError, OSError) as exc:
+            logging.warning("Could not read monitoring file %s: %s", file_path, exc)
+    return statuses
+
+
+__all__ = ["BotMonitor", "load_all_statuses"]

--- a/stock_bot_real_data.py
+++ b/stock_bot_real_data.py
@@ -10,6 +10,7 @@ import schedule
 import tweepy
 import requests
 from utils import create_session, post_with_retry
+from monitoring import BotMonitor
 from datetime import datetime
 from dotenv import load_dotenv
 import logging
@@ -45,10 +46,22 @@ class RealStockMarketBot:
 
         # HTTP session with retry logic for reliability
         self.session = create_session()
-        
+
+        # Monitoring helper to persist status between runs
+        self.monitor = BotMonitor('real_stock_market_bot')
+        self.monitor.record_event('info', 'RealStockMarketBot initialization started')
+
+        # Track whether we've already emitted certain warnings
+        self._alpha_warning_logged = False
+        self._news_warning_logged = False
+
         if not all([self.api_key, self.api_secret, self.access_token, self.access_token_secret]):
+            self.monitor.record_event(
+                'error',
+                'Missing X API credentials during initialization',
+            )
             raise ValueError("Missing X API credentials in .env file")
-        
+
         # Initialize X API v2 client
         try:
             self.client = tweepy.Client(
@@ -59,19 +72,31 @@ class RealStockMarketBot:
             )
         except Exception as e:
             logging.error(f"Could not initialize X client: {e}")
+            self.monitor.record_event('error', 'Failed to initialize X client', {'error': str(e)})
             raise
-        
+
         # Major stocks to track
         self.major_stocks = ['AAPL', 'MSFT', 'GOOGL', 'TSLA', 'NVDA']
-        
+
         logging.info("Real Stock Market Bot initialized successfully")
+        self.monitor.record_event(
+            'success',
+            'RealStockMarketBot initialized successfully',
+            {'tracked_stocks': self.major_stocks},
+        )
     
     def get_stock_data_alpha_vantage(self, symbol):
         """Get real stock data from Alpha Vantage"""
         if not self.alpha_vantage_key:
             logging.warning("No Alpha Vantage API key - using sample data")
+            if not self._alpha_warning_logged:
+                self.monitor.record_event(
+                    'warning',
+                    'Alpha Vantage API key missing; using sample data',
+                )
+                self._alpha_warning_logged = True
             return None
-        
+
         try:
             url = "https://www.alphavantage.co/query"
             params = {
@@ -85,18 +110,33 @@ class RealStockMarketBot:
             response.raise_for_status()
         except requests.RequestException as exc:
             logging.error(f"Network error getting data for {symbol}: {exc}")
+            self.monitor.record_event(
+                'error',
+                f'Network error retrieving {symbol} data from Alpha Vantage',
+                {'symbol': symbol, 'error': str(exc)},
+            )
             return None
 
         try:
             data = response.json()
         except ValueError as exc:
             logging.error(f"Invalid JSON response for {symbol}: {exc}")
+            self.monitor.record_event(
+                'error',
+                f'Invalid JSON response for {symbol} from Alpha Vantage',
+                {'symbol': symbol, 'error': str(exc)},
+            )
             return None
 
         if data.get('Note'):
             logging.warning(
                 "Alpha Vantage API limit reached while fetching data for %s",
                 symbol,
+            )
+            self.monitor.record_event(
+                'warning',
+                'Alpha Vantage API limit reached',
+                {'symbol': symbol},
             )
             return None
 
@@ -106,16 +146,31 @@ class RealStockMarketBot:
                 symbol,
                 data['Error Message'],
             )
+            self.monitor.record_event(
+                'error',
+                'Alpha Vantage returned an error response',
+                {'symbol': symbol, 'message': data['Error Message']},
+            )
             return None
 
         time_series = data.get('Time Series (Daily)')
         if not isinstance(time_series, dict):
             logging.warning(f"No time series data available for {symbol}")
+            self.monitor.record_event(
+                'warning',
+                'No time series data available in Alpha Vantage response',
+                {'symbol': symbol},
+            )
             return None
 
         dates = sorted(time_series.keys(), reverse=True)
         if len(dates) < 2:
             logging.warning(f"Not enough data points returned for {symbol}")
+            self.monitor.record_event(
+                'warning',
+                'Alpha Vantage returned insufficient data points',
+                {'symbol': symbol, 'dates_returned': len(dates)},
+            )
             return None
 
         today, yesterday = dates[0], dates[1]
@@ -124,6 +179,11 @@ class RealStockMarketBot:
             yesterday_close = float(time_series[yesterday]['4. close'])
         except (KeyError, TypeError, ValueError) as exc:
             logging.error(f"Invalid price data for {symbol}: {exc}")
+            self.monitor.record_event(
+                'error',
+                'Alpha Vantage returned invalid price data',
+                {'symbol': symbol, 'error': str(exc)},
+            )
             return None
 
         change = today_close - yesterday_close
@@ -140,8 +200,14 @@ class RealStockMarketBot:
         """Get real news for a stock from NewsAPI"""
         if not self.news_api_key:
             logging.warning("No News API key - using sample news")
+            if not self._news_warning_logged:
+                self.monitor.record_event(
+                    'warning',
+                    'News API key missing; using sample headlines',
+                )
+                self._news_warning_logged = True
             return self.get_sample_news(symbol)
-        
+
         try:
             # Get company name for better news search
             company_names = {
@@ -167,23 +233,43 @@ class RealStockMarketBot:
             response.raise_for_status()
         except requests.RequestException as exc:
             logging.error(f"Network error getting news for {symbol}: {exc}")
+            self.monitor.record_event(
+                'warning',
+                'Network error retrieving NewsAPI headlines',
+                {'symbol': symbol, 'error': str(exc)},
+            )
             return self.get_sample_news(symbol)
 
         try:
             data = response.json()
         except ValueError as exc:
             logging.error(f"Invalid news response for {symbol}: {exc}")
+            self.monitor.record_event(
+                'warning',
+                'Invalid JSON response from NewsAPI',
+                {'symbol': symbol, 'error': str(exc)},
+            )
             return self.get_sample_news(symbol)
 
         if data.get('status') != 'ok':
             logging.warning(
                 "News API returned status '%s' for %s", data.get('status'), symbol
             )
+            self.monitor.record_event(
+                'warning',
+                'NewsAPI returned a non-ok status',
+                {'symbol': symbol, 'status': data.get('status')},
+            )
             return self.get_sample_news(symbol)
 
         articles = data.get('articles') or []
         if not articles:
             logging.warning(f"No news articles found for {symbol}")
+            self.monitor.record_event(
+                'warning',
+                'No NewsAPI articles found',
+                {'symbol': symbol},
+            )
             return self.get_sample_news(symbol)
 
         for article in articles:
@@ -197,9 +283,14 @@ class RealStockMarketBot:
 
         title = (articles[0].get('title') or '').strip()
         if title:
-            return title[:100] + "..." if len(title) > 100 else title
+                return title[:100] + "..." if len(title) > 100 else title
 
         logging.warning(f"Articles lacked titles for {symbol}")
+        self.monitor.record_event(
+            'warning',
+            'NewsAPI articles lacked titles',
+            {'symbol': symbol},
+        )
         return self.get_sample_news(symbol)
     
     def get_sample_news(self, symbol):
@@ -216,23 +307,26 @@ class RealStockMarketBot:
     def get_market_data_with_news(self):
         """Get real market data with news"""
         market_data = {}
-        
+        real_symbols = []
+        sample_symbols = []
+
         for symbol in self.major_stocks:
             logging.info(f"Fetching data for {symbol}...")
-            
+
             # Get stock data
             stock_data = self.get_stock_data_alpha_vantage(symbol)
-            
+
             if stock_data:
                 # Get news for this stock
                 news = self.get_news_for_stock(symbol)
-                
+
                 market_data[symbol] = {
                     **stock_data,
                     'news': news
                 }
-                
+
                 logging.info(f"✅ {symbol}: ${stock_data['price']:.2f} ({stock_data['change_pct']:+.2f}%)")
+                real_symbols.append(symbol)
             else:
                 # Use sample data if no real data available
                 sample_data = {
@@ -250,10 +344,24 @@ class RealStockMarketBot:
                         'news': news
                     }
                     logging.info(f"⚠️ {symbol}: Using sample data")
-            
+                    sample_symbols.append(symbol)
+
             # Rate limiting - wait between requests
             time.sleep(1)
-        
+
+        if real_symbols:
+            self.monitor.record_event(
+                'info',
+                'Fetched live market data',
+                {'symbols': real_symbols},
+            )
+        if sample_symbols:
+            self.monitor.record_event(
+                'warning',
+                'Using sample market data for symbols',
+                {'symbols': sample_symbols},
+            )
+
         return market_data
     
     def analyze_market_changes(self, market_data):
@@ -334,28 +442,61 @@ class RealStockMarketBot:
     
     def run_market_update(self, is_morning=True):
         """Run the complete market update process"""
+        update_label = 'morning' if is_morning else 'evening'
         try:
             logging.info(f"Starting {'morning' if is_morning else 'evening'} market update")
-            
+            self.monitor.record_event('info', f'Starting {update_label} market update')
+
             # Get market data with news
             market_data = self.get_market_data_with_news()
-            
+
             # Analyze changes
             top_movers = self.analyze_market_changes(market_data)
-            
+
             # Format message
             message = self.format_market_update(top_movers, is_morning)
-            
+
+            run_metadata = {
+                'symbols_with_data': list(market_data.keys()),
+                'top_movers': [
+                    {
+                        'symbol': mover['symbol'],
+                        'change_pct': mover['change_pct'],
+                        'price': mover['price'],
+                    }
+                    for mover in top_movers
+                ],
+                'tweet_length': len(message),
+            }
+
             # Post to X
             success = self.post_to_x(message)
-            
+
             if success:
                 logging.info("Market update completed successfully")
+                self.monitor.record_run(
+                    update_label,
+                    'success',
+                    'Market update posted to X',
+                    run_metadata,
+                )
             else:
                 logging.error("Failed to post market update")
-                
+                self.monitor.record_run(
+                    update_label,
+                    'error',
+                    'Failed to post market update',
+                    run_metadata,
+                )
+
         except Exception as e:
             logging.error(f"Error in market update: {e}")
+            self.monitor.record_run(
+                update_label,
+                'error',
+                f'Exception during {update_label} update',
+                {'error': str(e)},
+            )
     
     def morning_update(self):
         """Morning market update (8 AM)"""
@@ -369,9 +510,10 @@ class RealStockMarketBot:
         """Start the scheduler to run updates at 8 AM and 8 PM"""
         schedule.every().day.at("08:00").do(self.morning_update)
         schedule.every().day.at("20:00").do(self.evening_update)
-        
+
         logging.info("Scheduler started - updates scheduled for 8:00 AM and 8:00 PM")
-        
+        self.monitor.record_event('info', 'Scheduler started for RealStockMarketBot')
+
         while True:
             schedule.run_pending()
             time.sleep(60)  # Check every minute


### PR DESCRIPTION
## Summary
- add a monitoring helper that records bot run status information in JSON files
- instrument the real, server, and weekend bots to emit monitoring events and run outcomes
- add a CLI for inspecting monitoring data plus documentation and ignore rules

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cc960529888323ab34face3133b870